### PR TITLE
v1.1.2

### DIFF
--- a/.github/workflows/package.json
+++ b/.github/workflows/package.json
@@ -9,7 +9,7 @@
     "display_name": "Spoon Anti-Warping Reborn",
     "package_id": "SpoonAntiWarpingReborn",
     "package_type": "plugin",
-    "package_version": "1.1.1",
+    "package_version": "1.1.2",
     "sdk_version": 8,
     "sdk_version_semver": "8.0.0",
     "website": "https://github.com/Slashee-the-Cow/SpoonAntiWarpingReborn/"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ They say "a picture is worth a thousand words". I think you deserve more than a 
 - In version 5.0 the dropdowns in the settings panel won't show their contents. This is a problem with Cura's theming. Since the active one *is* shown, you can just pick them in turn until you find the correct one.
 
 ## Version History
+### 1.1.2:
+- Spoons now have ironing disabled by default in case you are using ironing. This can be changed in the "Per Object Settings" tool by selecting a spoon.
+- Automatic spoon placement now takes all non-extrusion moves into account when removing combing.
+- Automatic spoon placement should have less chance of conflicting with other plugins/post-processing scripts if they insert code which doesn't follow Cura's syntax.
 ### 1.1.1:
 - Automatic spoon placement will now follow the base of the model touching the build plate rather than the overall outline.
 - If a model has multiple separate areas touching the build plate, automatic spoon placement will now run for all of them individually.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ They say "a picture is worth a thousand words". I think you deserve more than a 
 ## Known Issues
 - Due to a [bug in Cura](https://github.com/Ultimaker/Cura/issues/20488) it can try and place spoons in the wrong places sometimes. I've put in the best workarounds I know about at this point and it will automatically delete any spoons that would be placed off the build plate.
 - Print ordering uses settings from the first extruder. It might not work properly if different extruders have different settings.
+- In version 5.0 the dropdowns in the settings panel won't show their contents. This is a problem with Cura's theming. Since the active one *is* shown, you can just pick them in turn until you find the correct one.
 
 ## Version History
 ### 1.1.1:

--- a/SpoonAntiWarpingReborn.py
+++ b/SpoonAntiWarpingReborn.py
@@ -7,8 +7,9 @@
 #--------------------------------------------------------------------------------------------------------------------------------------
 # Version history (Reborn version)
 # v1.1.2:
-#   - Spoons now have ironing specifically turned off in case you're using it in the scene. If you want pretty spoons, you can turn it back on in the Per Object Settings tool.
-#   - Print ordering now takes G1/G2/G3 non-extrusion moves into account when removing combing moves.
+#   - Spoons now have ironing specifically disabled in case you're using it in the scene. If you want pretty spoons, you can turn it back on in the Per Object Settings tool.
+#   - Print ordering now takes G1/G2/G3 non-extrusion moves into account when removing combing moves because when I add checks for G2/G3 moves I neglected to add them everywhere.
+#   - Print ordering now checks for Z hop moves which don't follow Cura's syntax in case another plugin or script decides not to follow that syntax.
 # v1.1.1:
 #   - Automatic spoon placement now follows the part of model that touches the build plate. Remarkably this took me less time than manually adding/removing spoons to about four complex objects with the original behaviour.
 #   - If a model has separate areas on the build plate, they are now individually run through automatic placement. Reduces instances of monitor punching by approximately 93% compared to the original behaviour.
@@ -191,6 +192,11 @@ class SpoonAntiWarpingReborn(Tool):
 
         # Connect order script to write start
         self._application.getOutputDeviceManager().writeStarted.connect(self._run_spoon_order)
+        # Connect order script connector to plugins loaded
+        #self._application.pluginsLoaded.connect(self._connect_write_signal)
+
+    #def _connect_write_signal(self):
+        #self._application.getOutputDeviceManager().writeStarted.connect(self._run_spoon_order)
 
     def event(self, event: Event) -> None:
         super().event(event)
@@ -1109,7 +1115,7 @@ class SpoonAntiWarpingReborn(Tool):
         return mesh_data
 
     def _run_spoon_order(self, output_device) -> None:
-        log("d", f"_run_spoon_order running with _print_order of {self._print_order}")
+        log("i", f"Spoon Anti-Warping Reborn: _run_spoon_order running with _print_order of {self._print_order}")
         match self._print_order:
             case "Unchanged":
                 return
@@ -1124,7 +1130,7 @@ class SpoonAntiWarpingReborn(Tool):
         gcode_dict = getattr(scene, "gcode_dict", {})
         for plate_id in gcode_dict:
             for layer in gcode_dict[plate_id]:
-                log("i", layer.replace("\n",","))
+                log("d", layer.replace("\n",","))
             gcode_dict[plate_id] = self._order_script.execute(gcode_dict[plate_id])
 
     def getSpoonDiameter(self) -> float:

--- a/SpoonAntiWarpingReborn.py
+++ b/SpoonAntiWarpingReborn.py
@@ -8,6 +8,7 @@
 # Version history (Reborn version)
 # v1.1.2:
 #   - Spoons now have ironing specifically turned off in case you're using it in the scene. If you want pretty spoons, you can turn it back on in the Per Object Settings tool.
+#   - Print ordering now takes G1/G2/G3 non-extrusion moves into account when removing combing moves.
 # v1.1.1:
 #   - Automatic spoon placement now follows the part of model that touches the build plate. Remarkably this took me less time than manually adding/removing spoons to about four complex objects with the original behaviour.
 #   - If a model has separate areas on the build plate, they are now individually run through automatic placement. Reduces instances of monitor punching by approximately 93% compared to the original behaviour.

--- a/SpoonAntiWarpingReborn.py
+++ b/SpoonAntiWarpingReborn.py
@@ -6,6 +6,8 @@
 # https://github.com/5axes/SpoonAntiWarping
 #--------------------------------------------------------------------------------------------------------------------------------------
 # Version history (Reborn version)
+# v1.1.2:
+#   - Spoons now have ironing specifically turned off in case you're using it in the scene. If you want pretty spoons, you can turn it back on in the Per Object Settings tool.
 # v1.1.1:
 #   - Automatic spoon placement now follows the part of model that touches the build plate. Remarkably this took me less time than manually adding/removing spoons to about four complex objects with the original behaviour.
 #   - If a model has separate areas on the build plate, they are now individually run through automatic placement. Reduces instances of monitor punching by approximately 93% compared to the original behaviour.
@@ -417,6 +419,12 @@ class SpoonAntiWarpingReborn(Tool):
         new_instance = SettingInstance(definition, settings)
         new_instance.setProperty("value", 49) #50 "maximum_value_warning": "50"
         new_instance.resetState()  # Ensure that the state is not seen as a user state.
+        settings.addInstance(new_instance)
+
+        definition = stack.getSettingDefinition("ironing_enabled")
+        new_instance = SettingInstance(definition, settings)
+        new_instance.setProperty("value", False)
+        new_instance.resetState()  # Slashee says: I'm not sure if this actually does anything
         settings.addInstance(new_instance)
 
         # First add node to the scene at the correct position/scale, before parenting, so the Spoon mesh does not get scaled with the parent

--- a/SpoonOrder.py
+++ b/SpoonOrder.py
@@ -212,7 +212,8 @@ class SpoonOrder:
                         section_start_travel_count = 0
                         # This isn't changing any lines, just examining what we've got.
                         for start_line in current_section.lines[:section_extrude_start_index]:
-                            if start_line.startswith("G0") or (start_line.startswith(("G2", "G3")) and "E" not in start_line):
+                            if ((start_line.startswith("G0") and ("X" in start_line or "Y" in start_line))  # Cura generates moves straight along the Z axis with X and Y coordinates anyway. Some disagree.
+                                or (start_line.startswith(("G2", "G3")) and "E" not in start_line)):
                                 section_start_travel_count += 1
                                
                                 start_line_x = get_value(start_line, "X")
@@ -236,7 +237,8 @@ class SpoonOrder:
                             new_start_lines: list[str] = []
                             travel_count = 0
                             for start_line in current_section.lines[:section_extrude_start_index]:
-                                if start_line.startswith("G0") or (start_line.startswith(("G1", "G2", "G3")) and "E" not in start_line):
+                                if ((start_line.startswith("G0") and ("X" in start_line or "Y" in start_line))
+                                    or (start_line.startswith(("G1", "G2", "G3")) and "E" not in start_line)):
                                     travel_count += 1
                                     if travel_count == current_section.start_travel_moves:
                                         new_start_lines.append(start_line)

--- a/SpoonOrder.py
+++ b/SpoonOrder.py
@@ -35,7 +35,7 @@ class GcodeSection:
     end_e: float = 0.0
 
     start_has_move: bool = False
-    start_g0_moves: int = 0
+    start_travel_moves: int = 0
     start_has_zdown: bool = False
     start_has_prime: bool = False
 
@@ -209,11 +209,11 @@ class SpoonOrder:
                                 log("d", f"section_extrude_start_index for {current_section.name} on layer {layer_index} is {section_extrude_start_index}")
                                 break
                             
-                        section_start_g0_count = 0
+                        section_start_travel_count = 0
                         # This isn't changing any lines, just examining what we've got.
                         for start_line in current_section.lines[:section_extrude_start_index]:
                             if start_line.startswith("G0") or (start_line.startswith(("G2", "G3")) and "E" not in start_line):
-                                section_start_g0_count += 1
+                                section_start_travel_count += 1
                                
                                 start_line_x = get_value(start_line, "X")
                                 start_line_y = get_value(start_line, "Y")
@@ -231,14 +231,14 @@ class SpoonOrder:
                             current_section.start_has_move = True
 
                         # Remove any combing G0 moves there might be
-                        current_section.start_g0_moves = section_start_g0_count
-                        if current_section.start_g0_moves > 1:
+                        current_section.start_travel_moves = section_start_travel_count
+                        if current_section.start_travel_moves > 1:
                             new_start_lines: list[str] = []
-                            g0_count = 0
+                            travel_count = 0
                             for start_line in current_section.lines[:section_extrude_start_index]:
-                                if start_line.startswith("G0"):
-                                    g0_count += 1
-                                    if g0_count == current_section.start_g0_moves:
+                                if start_line.startswith("G0") or (start_line.startswith(("G1", "G2", "G3")) and "E" not in start_line):
+                                    travel_count += 1
+                                    if travel_count == current_section.start_travel_moves:
                                         new_start_lines.append(start_line)
                                 else:
                                     new_start_lines.append(start_line)

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "Spoon Anti-Warping Reborn",
     "author": "Slashee the Cow",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "Add \"spoons\" to parts of models to help prevent warping. Originally by 5@xes.",
     "i18n-catalog": "spoonawreborn",
     "api": 8,

--- a/script_helpers.py
+++ b/script_helpers.py
@@ -83,7 +83,7 @@ def put_value(line: str = "", **kwargs) -> str:
 
 def is_z_hop_line(line: str, z_hop_speed: float = None) -> bool:
     """Returns if a line is (likely) a Z hop (up or down) based on Cura's usual pattern"""
-    return ("G1" in line
+    return (("G1" in line or "G0" in line)  # Apparently some geniuses use G0 when generating Z hops
             and ("F" if z_hop_speed is None else f"F{str(int(z_hop_speed)) if z_hop_speed % 1 == 0.0 else str(z_hop_speed)}") in line
             and "Z" in line
             and "E" not in line
@@ -239,7 +239,7 @@ def make_travel(x: float, y: float, speed: float, z: float = None,
           f"has_start_move: {has_start_move}, has_start_zdown: {has_start_zdown}, has_start_prime: {has_start_prime}, starts_retracted: {starts_retracted}, relative_extrusion: {relative_extrusion}")
     if relative_extrusion:
         e = 0.0
-    output: str = "; SpoonOrder added travel\n"
+    output: str = "; SpoonOrder added travel start\n"
     if e is not None and not relative_extrusion:
         # Reset extruder value
         output += f"G92 E{round(e,5) if not starts_retracted else round(e-retract_distance,5)}\n"
@@ -257,5 +257,6 @@ def make_travel(x: float, y: float, speed: float, z: float = None,
     if retraction and not has_start_prime:
         # Prime filament
         output += f"G1 F{str(int(prime_speed))} E{round(e,5) if not relative_extrusion else retract_distance}"
+    output += "; SpoonOrder added travel end\n"
     log("d", f"make_travel output:\n{output}")
     return output


### PR DESCRIPTION
- Spoons now have ironing disabled by default in case you are using ironing. This can be changed in the "Per Object Settings" tool by selecting a spoon.
- Automatic spoon placement now takes all non-extrusion moves into account when removing combing.
- Automatic spoon placement should have less chance of conflicting with other plugins/post-processing scripts if they insert code which doesn't follow Cura's syntax.